### PR TITLE
Avoid algebraic loop in when-equation

### DIFF
--- a/IndustrialControlSystems/Logical/Timers/Timer_On.mo
+++ b/IndustrialControlSystems/Logical/Timers/Timer_On.mo
@@ -15,7 +15,7 @@ equation
         pre(Sd),
         Sd,
         R,
-        startTime,
+        pre(startTime),
         time);
     (run,Q) = IndustrialControlSystems.Logical.Timers.Functions.tim(
         S,


### PR DESCRIPTION
I assume it was desired to use `pre(startTime)` in the when-statement and not to create an algebraic loop.